### PR TITLE
Add TargetsDistanceInches / TargetsSizeInches Fields

### DIFF
--- a/assets/Scripts/Managers/GameManager.cs
+++ b/assets/Scripts/Managers/GameManager.cs
@@ -498,6 +498,8 @@ public class GameManager : MonoBehaviour
 
     private static void MakeLogEntry(string _hitType)
     {
+
+
         int temp = -1;
 
         if (gameType == GameType.Tunnel) 
@@ -515,6 +517,19 @@ public class GameManager : MonoBehaviour
 
 
 
+        int temp2 = -1;
+
+        if (gameType == GameType.Tunnel){
+
+            temp2 = S_tunnel;
+
+        } else if (gameType == GameType.Fitts){
+            temp2 = S_fitts;
+
+        } else if (gameType == GameType.Goal){
+            temp2 = S_goal;
+        }
+
 
         LoggingManager.NewEntry(gameType, _hitType,
             targetNumber,
@@ -529,7 +544,8 @@ public class GameManager : MonoBehaviour
             outsetHit,
             backtracking,
             errorTargetID,
-            temp);
+            temp,
+            temp2);
     }
 
     private static void PrepareFittsGame()

--- a/assets/Scripts/Managers/GameManager.cs
+++ b/assets/Scripts/Managers/GameManager.cs
@@ -498,6 +498,23 @@ public class GameManager : MonoBehaviour
 
     private static void MakeLogEntry(string _hitType)
     {
+        int temp = -1;
+
+        if (gameType == GameType.Tunnel) 
+        {
+            temp = D_tunnel;
+        }
+        else if (gameType == GameType.Fitts)
+        {
+            temp = D_fitts;
+        }
+        else if (gameType == GameType.Goal)
+        {
+            temp = D_goal;
+        }
+
+
+
 
         LoggingManager.NewEntry(gameType, _hitType,
             targetNumber,
@@ -511,7 +528,8 @@ public class GameManager : MonoBehaviour
             outsetTarget,
             outsetHit,
             backtracking,
-            errorTargetID);
+            errorTargetID,
+            temp);
     }
 
     private static void PrepareFittsGame()

--- a/assets/Scripts/Managers/LoggingManager.cs
+++ b/assets/Scripts/Managers/LoggingManager.cs
@@ -58,7 +58,7 @@ public class LoggingManager : MonoBehaviour {
 	public static InputResponders _inputResponders;
 	public static InputType _inputType;
 
-	private static string headers = "Date;Time;UserID;GameType;InputType;InputResponders;HitType;TargetNumber;TargetID;SessionTime;DeltaTime;TargetX;TargetY;HitX;HitY;HitOffsetX;HitOffsetY;OutsetTargetX;OutsetTargetY;TargetDeltaX;TargetDeltaY;OutsetHitX;OutsetHitY;DeltaHitX;DeltaHitY;TargetDiameter;ColliderDiameter;Backtracking;ErrorTargetID;TargetsDistanceInches";
+	private static string headers = "Date;Time;UserID;GameType;InputType;InputResponders;HitType;TargetNumber;TargetID;SessionTime;DeltaTime;TargetX;TargetY;HitX;HitY;HitOffsetX;HitOffsetY;OutsetTargetX;OutsetTargetY;TargetDeltaX;TargetDeltaY;OutsetHitX;OutsetHitY;DeltaHitX;DeltaHitY;TargetDiameter;ColliderDiameter;Backtracking;ErrorTargetID;TargetsDistanceInches,TargetsSizeeInches";
 
 	private static StreamWriter writer;
 	private static string directory;
@@ -118,7 +118,8 @@ public class LoggingManager : MonoBehaviour {
 			{"ColliderDiameter", new List<string>()},
 			{"Backtracking", new List<string>()},
 			{"ErrorTargetID", new List<string>()},
-			{"TargetsDistanceInches", new List<string>()}
+			{"TargetsDistanceInches", new List<string>()},
+			{"TargetsSizeInches", new List<string>()}
 			
 
 
@@ -200,7 +201,8 @@ public class LoggingManager : MonoBehaviour {
 	                     Vector2 _outsetHit,
 						 bool _backtracking,
 						 int _errorTargetID,
-						 int _dTemp) {
+						 int _dTemp,
+						 int _sTemp2) {
 
 		date = System.DateTime.Now.ToString("yyyy-MM-dd");
 		time = System.DateTime.Now.ToString("HH:mm:ss:ffff");
@@ -237,7 +239,8 @@ public class LoggingManager : MonoBehaviour {
 						_collider + sep +
 						_backtracking + sep +
 						_errorTargetID + sep +
-						_dTemp;
+						_dTemp + sep +
+						_sTemp2;
 						// _dFitt+ sep +
 						// _dTunnel;
 
@@ -279,6 +282,7 @@ public class LoggingManager : MonoBehaviour {
 		logs["Backtracking"].Add(_backtracking.ToString());
 		logs["ErrorTargetID"].Add(_errorTargetID.ToString());
 		logs["TargetsDistanceInches"].Add(_dTemp.ToString());
+		logs["TargetsSizeInches"].Add(_sTemp2.ToString());
 
 
 		

--- a/assets/Scripts/Managers/LoggingManager.cs
+++ b/assets/Scripts/Managers/LoggingManager.cs
@@ -58,7 +58,7 @@ public class LoggingManager : MonoBehaviour {
 	public static InputResponders _inputResponders;
 	public static InputType _inputType;
 
-	private static string headers = "Date;Time;UserID;GameType;InputType;InputResponders;HitType;TargetNumber;TargetID;SessionTime;DeltaTime;TargetX;TargetY;HitX;HitY;HitOffsetX;HitOffsetY;OutsetTargetX;OutsetTargetY;TargetDeltaX;TargetDeltaY;OutsetHitX;OutsetHitY;DeltaHitX;DeltaHitY;TargetDiameter;ColliderDiameter;Backtracking;ErrorTargetID;TargetsDistance";
+	private static string headers = "Date;Time;UserID;GameType;InputType;InputResponders;HitType;TargetNumber;TargetID;SessionTime;DeltaTime;TargetX;TargetY;HitX;HitY;HitOffsetX;HitOffsetY;OutsetTargetX;OutsetTargetY;TargetDeltaX;TargetDeltaY;OutsetHitX;OutsetHitY;DeltaHitX;DeltaHitY;TargetDiameter;ColliderDiameter;Backtracking;ErrorTargetID;TargetsDistanceInches";
 
 	private static StreamWriter writer;
 	private static string directory;
@@ -118,7 +118,7 @@ public class LoggingManager : MonoBehaviour {
 			{"ColliderDiameter", new List<string>()},
 			{"Backtracking", new List<string>()},
 			{"ErrorTargetID", new List<string>()},
-			{"TargetsDistance", new List<string>()}
+			{"TargetsDistanceInches", new List<string>()}
 			
 
 
@@ -278,7 +278,7 @@ public class LoggingManager : MonoBehaviour {
 		logs["ColliderDiameter"].Add(_diameter.ToString());
 		logs["Backtracking"].Add(_backtracking.ToString());
 		logs["ErrorTargetID"].Add(_errorTargetID.ToString());
-		logs["TargetsDistance"].Add(_dTemp.ToString());
+		logs["TargetsDistanceInches"].Add(_dTemp.ToString());
 
 
 		

--- a/assets/Scripts/Managers/LoggingManager.cs
+++ b/assets/Scripts/Managers/LoggingManager.cs
@@ -58,7 +58,7 @@ public class LoggingManager : MonoBehaviour {
 	public static InputResponders _inputResponders;
 	public static InputType _inputType;
 
-	private static string headers = "Date;Time;UserID;GameType;InputType;InputResponders;HitType;TargetNumber;TargetID;SessionTime;DeltaTime;TargetX;TargetY;HitX;HitY;HitOffsetX;HitOffsetY;OutsetTargetX;OutsetTargetY;TargetDeltaX;TargetDeltaY;OutsetHitX;OutsetHitY;DeltaHitX;DeltaHitY;TargetDiameter;ColliderDiameter;Backtracking;ErrorTargetID";
+	private static string headers = "Date;Time;UserID;GameType;InputType;InputResponders;HitType;TargetNumber;TargetID;SessionTime;DeltaTime;TargetX;TargetY;HitX;HitY;HitOffsetX;HitOffsetY;OutsetTargetX;OutsetTargetY;TargetDeltaX;TargetDeltaY;OutsetHitX;OutsetHitY;DeltaHitX;DeltaHitY;TargetDiameter;ColliderDiameter;Backtracking;ErrorTargetID;TargetsDistance";
 
 	private static StreamWriter writer;
 	private static string directory;
@@ -118,6 +118,7 @@ public class LoggingManager : MonoBehaviour {
 			{"ColliderDiameter", new List<string>()},
 			{"Backtracking", new List<string>()},
 			{"ErrorTargetID", new List<string>()},
+			{"TargetsDistance", new List<string>()}
 			
 
 
@@ -183,6 +184,7 @@ public class LoggingManager : MonoBehaviour {
 	public void onInputResponder_Changed() {
 		_inputResponders = (InputResponders) inputResponderDropdown.value;
 	}
+
 	public static void NewEntry(GameType _gameType, 
 
 						 string _hitType,
@@ -197,13 +199,13 @@ public class LoggingManager : MonoBehaviour {
 	                     Vector2 _outsetTarget, 
 	                     Vector2 _outsetHit,
 						 bool _backtracking,
-						 int _errorTargetID) {
+						 int _errorTargetID,
+						 int _dTemp) {
 
 		date = System.DateTime.Now.ToString("yyyy-MM-dd");
 		time = System.DateTime.Now.ToString("HH:mm:ss:ffff");
 
 	
-
 
 
 		currentEntry = 	date + sep +
@@ -234,7 +236,10 @@ public class LoggingManager : MonoBehaviour {
 						_diameter + sep +
 						_collider + sep +
 						_backtracking + sep +
-						_errorTargetID;
+						_errorTargetID + sep +
+						_dTemp;
+						// _dFitt+ sep +
+						// _dTunnel;
 
 		using (StreamWriter writer = File.AppendText(directory + fileName))
 		{
@@ -273,7 +278,8 @@ public class LoggingManager : MonoBehaviour {
 		logs["ColliderDiameter"].Add(_diameter.ToString());
 		logs["Backtracking"].Add(_backtracking.ToString());
 		logs["ErrorTargetID"].Add(_errorTargetID.ToString());
-		
+		logs["TargetsDistance"].Add(_dTemp.ToString());
+
 
 		
 		
@@ -281,8 +287,11 @@ public class LoggingManager : MonoBehaviour {
 
 		public void sendLogs(){              //Send the logs
 
+		if (logs["Email"].Count == 0)       
+		 return;
+
 		connectToMySQL.AddToUploadQueue(logs);  //
-		connectToMySQL.UploadNow();			//
+		connectToMySQL.UploadNow();			
 
 		resetLogs();
 		}


### PR DESCRIPTION
This pull request is made to add an extra field into the database: 

Logs : Addition of the TargetsDistance field on the DB,  which contains the  values of the target size of the three game mode (Tunnel-Fitts and Goal) selected and use it to visualize it in terms of human performance on R Shiny app.

![Capture](https://user-images.githubusercontent.com/45661981/70905956-85352780-2005-11ea-9e81-a4b9bb0e5bb3.PNG)

Some bugs are fixed, regarding the selection of game type before the game is launched by sending empty log and returned an error message on Unity.