### PR TITLE
R shiny extra logs

### DIFF
--- a/assets/Scripts/Managers/GameManager.cs
+++ b/assets/Scripts/Managers/GameManager.cs
@@ -115,6 +115,8 @@ public class GameManager : MonoBehaviour
 
     private string GameInstructionsTemplate;
 
+    private static string testId = "";
+
     void Awake()
     {
         GameInstructionsTemplate = customGameInstructions.text;
@@ -285,6 +287,8 @@ public class GameManager : MonoBehaviour
             PrepareGoalGame();
         else if (gameType == GameType.Custom)
             customGameInstructions.text = "Now logging the Arduino..";
+        
+        testId = System.DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
 
         if (targetAttributes.Length > 0)
         {
@@ -511,7 +515,8 @@ public class GameManager : MonoBehaviour
             outsetTarget,
             outsetHit,
             backtracking,
-            errorTargetID);
+            errorTargetID,
+            testId);
     }
 
     private static void PrepareFittsGame()

--- a/assets/Scripts/Managers/GameManager.cs
+++ b/assets/Scripts/Managers/GameManager.cs
@@ -115,7 +115,7 @@ public class GameManager : MonoBehaviour
 
     private string GameInstructionsTemplate;
 
-    private static string testId = "";
+    private static string dateId = "";
 
     void Awake()
     {
@@ -288,7 +288,7 @@ public class GameManager : MonoBehaviour
         else if (gameType == GameType.Custom)
             customGameInstructions.text = "Now logging the Arduino..";
         
-        testId = System.DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+        dateId = System.DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
 
         if (targetAttributes.Length > 0)
         {
@@ -516,7 +516,7 @@ public class GameManager : MonoBehaviour
             outsetHit,
             backtracking,
             errorTargetID,
-            testId);
+            dateId);
     }
 
     private static void PrepareFittsGame()

--- a/assets/Scripts/Managers/LoggingManager.cs
+++ b/assets/Scripts/Managers/LoggingManager.cs
@@ -58,7 +58,7 @@ public class LoggingManager : MonoBehaviour {
 	public static InputResponders _inputResponders;
 	public static InputType _inputType;
 
-	private static string headers = "Date;Time;UserID;GameType;InputType;InputResponders;HitType;TargetNumber;TargetID;SessionTime;DeltaTime;TargetX;TargetY;HitX;HitY;HitOffsetX;HitOffsetY;OutsetTargetX;OutsetTargetY;TargetDeltaX;TargetDeltaY;OutsetHitX;OutsetHitY;DeltaHitX;DeltaHitY;TargetDiameter;ColliderDiameter;Backtracking;ErrorTargetID";
+	private static string headers = "Date;Time;UserID;GameType;InputType;InputResponders;HitType;TargetNumber;TargetID;SessionTime;DeltaTime;TargetX;TargetY;HitX;HitY;HitOffsetX;HitOffsetY;OutsetTargetX;OutsetTargetY;TargetDeltaX;TargetDeltaY;OutsetHitX;OutsetHitY;DeltaHitX;DeltaHitY;TargetDiameter;ColliderDiameter;Backtracking;ErrorTargetID;TestId";
 
 	private static StreamWriter writer;
 	private static string directory;
@@ -81,6 +81,7 @@ public class LoggingManager : MonoBehaviour {
 
 	[SerializeField]
 	private InputField emailField;
+
 	public void Awake() {
 
 		connectToMySQL = FindObjectOfType<ConnectToMySQL>();
@@ -118,7 +119,7 @@ public class LoggingManager : MonoBehaviour {
 			{"ColliderDiameter", new List<string>()},
 			{"Backtracking", new List<string>()},
 			{"ErrorTargetID", new List<string>()},
-			
+			{"TestId", new List<string>()}
 
 
 		}; 
@@ -197,13 +198,14 @@ public class LoggingManager : MonoBehaviour {
 	                     Vector2 _outsetTarget, 
 	                     Vector2 _outsetHit,
 						 bool _backtracking,
-						 int _errorTargetID) {
+						 int _errorTargetID,
+						 string _testId) {
 
 		date = System.DateTime.Now.ToString("yyyy-MM-dd");
 		time = System.DateTime.Now.ToString("HH:mm:ss:ffff");
 
 	
-
+		Debug.Log(_testId);
 
 
 		currentEntry = 	date + sep +
@@ -234,7 +236,8 @@ public class LoggingManager : MonoBehaviour {
 						_diameter + sep +
 						_collider + sep +
 						_backtracking + sep +
-						_errorTargetID;
+						_errorTargetID + sep +
+						_testId;
 
 		using (StreamWriter writer = File.AppendText(directory + fileName))
 		{
@@ -273,7 +276,7 @@ public class LoggingManager : MonoBehaviour {
 		logs["ColliderDiameter"].Add(_diameter.ToString());
 		logs["Backtracking"].Add(_backtracking.ToString());
 		logs["ErrorTargetID"].Add(_errorTargetID.ToString());
-		
+		logs["TestId"].Add(_testId.ToString());
 
 		
 		
@@ -300,6 +303,7 @@ public class LoggingManager : MonoBehaviour {
 		fileName = fileName.Replace ('/', '-');
 		fileName = fileName.Replace (':', '-');
 		*/
+
 		fileName = "rtii_output.csv";
 		if (!File.Exists(directory + fileName)) {
 			using (StreamWriter writer = File.AppendText(directory + fileName))

--- a/assets/Scripts/Managers/LoggingManager.cs
+++ b/assets/Scripts/Managers/LoggingManager.cs
@@ -58,7 +58,7 @@ public class LoggingManager : MonoBehaviour {
 	public static InputResponders _inputResponders;
 	public static InputType _inputType;
 
-	private static string headers = "Date;Time;UserID;GameType;InputType;InputResponders;HitType;TargetNumber;TargetID;SessionTime;DeltaTime;TargetX;TargetY;HitX;HitY;HitOffsetX;HitOffsetY;OutsetTargetX;OutsetTargetY;TargetDeltaX;TargetDeltaY;OutsetHitX;OutsetHitY;DeltaHitX;DeltaHitY;TargetDiameter;ColliderDiameter;Backtracking;ErrorTargetID;TestId";
+	private static string headers = "Date;Time;UserID;GameType;InputType;InputResponders;HitType;TargetNumber;TargetID;SessionTime;DeltaTime;TargetX;TargetY;HitX;HitY;HitOffsetX;HitOffsetY;OutsetTargetX;OutsetTargetY;TargetDeltaX;TargetDeltaY;OutsetHitX;OutsetHitY;DeltaHitX;DeltaHitY;TargetDiameter;ColliderDiameter;Backtracking;ErrorTargetID;DateId";
 
 	private static StreamWriter writer;
 	private static string directory;
@@ -119,7 +119,7 @@ public class LoggingManager : MonoBehaviour {
 			{"ColliderDiameter", new List<string>()},
 			{"Backtracking", new List<string>()},
 			{"ErrorTargetID", new List<string>()},
-			{"TestId", new List<string>()}
+			{"DateId", new List<string>()}
 
 
 		}; 
@@ -199,13 +199,13 @@ public class LoggingManager : MonoBehaviour {
 	                     Vector2 _outsetHit,
 						 bool _backtracking,
 						 int _errorTargetID,
-						 string _testId) {
+						 string _dateId) {
 
 		date = System.DateTime.Now.ToString("yyyy-MM-dd");
 		time = System.DateTime.Now.ToString("HH:mm:ss:ffff");
 
 	
-		Debug.Log(_testId);
+		Debug.Log(_dateId);
 
 
 		currentEntry = 	date + sep +
@@ -237,7 +237,7 @@ public class LoggingManager : MonoBehaviour {
 						_collider + sep +
 						_backtracking + sep +
 						_errorTargetID + sep +
-						_testId;
+						_dateId;
 
 		using (StreamWriter writer = File.AppendText(directory + fileName))
 		{
@@ -276,7 +276,7 @@ public class LoggingManager : MonoBehaviour {
 		logs["ColliderDiameter"].Add(_diameter.ToString());
 		logs["Backtracking"].Add(_backtracking.ToString());
 		logs["ErrorTargetID"].Add(_errorTargetID.ToString());
-		logs["TestId"].Add(_testId.ToString());
+		logs["DateId"].Add(_dateId.ToString());
 
 		
 		


### PR DESCRIPTION
#28 
Added a new field named "DateId" in the DB which can allow us to get back the full periode including the date and the execution time. it can be easier to use rather than use each field separately (Date-Time & SessionTime). 

![TestId](https://user-images.githubusercontent.com/45661981/71893457-089cf100-314c-11ea-9db8-c80ad37ddbc3.PNG)
