### PR TITLE
Revert "Horizontal Tunnel Limit"

### DIFF
--- a/assets/Scripts/Managers/GameManager.cs
+++ b/assets/Scripts/Managers/GameManager.cs
@@ -597,32 +597,24 @@ public class GameManager : MonoBehaviour
 
         Bounds b = CameraBounds();
         float barPos = ((b.extents.y - (S_tunnel / 2))/2) + (S_tunnel / 2);
-        float barPosX = ((b.extents.x - (S_tunnel / 2))/2) + (S_tunnel * 1.3f);
         float barHeight = (b.extents.y - (S_tunnel / 2));
-        float barWidth = (b.extents.x - (S_tunnel * 4.3f));
 
         if (allTargetObjects == null) {
             totalTargets = 2;
             allTunnelTarget = new TunnelTarget[totalTargets];
             allTargetObjects = new GameObject[totalTargets];
-            allTunnelBars = new TunnelBar[4];
-            allBarObjects = new GameObject[4];
+            allTunnelBars = new TunnelBar[2];
+            allBarObjects = new GameObject[2];
             Debug.Log("Preparing Tunnel Game");
 
             allBarObjects[0] = Instantiate(Resources.Load("Prefabs/TunnelBar", typeof(GameObject)), new Vector2(0, barPos), Quaternion.identity) as GameObject;
             allTunnelBars[0] = allBarObjects[0].GetComponent<TunnelBar>();
             allBarObjects[1] = Instantiate(Resources.Load("Prefabs/TunnelBar", typeof(GameObject)), new Vector2(0, -barPos), Quaternion.identity) as GameObject;
             allTunnelBars[1] = allBarObjects[1].GetComponent<TunnelBar>();
-            allBarObjects[2] = Instantiate(Resources.Load("Prefabs/TunnelBar", typeof(GameObject)), new Vector2(barPosX, 0), Quaternion.identity) as GameObject;
-            allTunnelBars[2] = allBarObjects[2].GetComponent<TunnelBar>();
-            allBarObjects[3] = Instantiate(Resources.Load("Prefabs/TunnelBar", typeof(GameObject)), new Vector2(-barPosX, 0), Quaternion.identity) as GameObject;
-            allTunnelBars[3] = allBarObjects[3].GetComponent<TunnelBar>();
         }
 
-        allTunnelBars[0].SetSize((int)b.extents.x * 2, (int)barHeight);
+        allTunnelBars[0].SetSize((int)b.extents.x*2, (int)barHeight);
         allTunnelBars[1].SetSize((int)b.extents.x * 2, (int)barHeight);
-        allTunnelBars[2].SetSize((int)barWidth, (int)b.extents.y * 2);
-        allTunnelBars[3].SetSize((int)barWidth, (int)b.extents.y * 2);
 
         Debug.Log("CamRect: " + CameraBounds());
         Debug.Log("allTargetObjects  count: " + allTargetObjects.Length);

--- a/assets/Scripts/Managers/InputManager.cs
+++ b/assets/Scripts/Managers/InputManager.cs
@@ -137,7 +137,7 @@ public class InputManager : MonoBehaviour {
 		crossingY = (prevWorldPosition.y + worldPosition.y) / 2;
         float crossingX = (prevWorldPosition.x + worldPosition.x) / 2;
 
-        for (int i = 0; i < 4; i++)
+        for (int i = 0; i < 2; i++)
         {
             if (GameManager.GetTunnelBars(i).GetComponent<TunnelBar>().IsNewHit())
             {


### PR DESCRIPTION
#2 
@bastianilso @hendrikknoche this pull request is made to reverse to the initial look of the tunnel mode, which should be limited only vertically.


This reverts commit 47ae19d9d5fbc5d81ffaf3fd5f505d6851baa387.

![TunnelLimitation](https://user-images.githubusercontent.com/45661981/72791868-57608580-3c38-11ea-9a92-5b20d8e81d0d.gif)
